### PR TITLE
Implement VOOG intro overlay targets

### DIFF
--- a/components/blog-article-template.tpl
+++ b/components/blog-article-template.tpl
@@ -13,7 +13,7 @@
   {% if blog-article-template == "blog_article_page" %}
     <div class="article-content">
       <div class="article-excerpt content-area" data-search-indexing-allowed="true">{% editable article.excerpt %}</div>
-      <div class="article-body content-area" data-search-indexing-allowed="true">{% editable article.body %}</div>
+      <div class="article-body content-area" data-search-indexing-allowed="true" {{ edy_intro_edit_text }}>{% editable article.body %}</div>
     </div>
   {% comment %}<!--Blog and news excerpt when no article photo-->{% endcomment %}
   {% else %}

--- a/components/blog-article-template.tpl
+++ b/components/blog-article-template.tpl
@@ -12,8 +12,8 @@
   {% comment %}<!--Blog article page excerpt and body-->{% endcomment %}
   {% if blog-article-template == "blog_article_page" %}
     <div class="article-content">
-      <div class="article-excerpt content-area" data-search-indexing-allowed="true">{% editable article.excerpt %}</div>
-      <div class="article-body content-area" data-search-indexing-allowed="true" {{ edy_intro_edit_text }}>{% editable article.body %}</div>
+      <div class="article-excerpt content-area" data-search-indexing-allowed="true" {{ edy_intro_edit_text }}>{% editable article.excerpt %}</div>
+      <div class="article-body content-area" data-search-indexing-allowed="true">{% editable article.body %}</div>
     </div>
   {% comment %}<!--Blog and news excerpt when no article photo-->{% endcomment %}
   {% else %}

--- a/components/menu-language.tpl
+++ b/components/menu-language.tpl
@@ -5,7 +5,7 @@
 {% if editmode or site.has_many_languages? %}
   {% if editmode or flags_state == true or numb_of_lang > 2 %}
     <div class="menu-btn-wrap js-menu-btn-wrap {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}">
-      <button role="button" class="lang-menu-btn js-lang-menu-btn js-popup-menu-btn js-prevent-sideclick lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}">
+      <button role="button" class="lang-menu-btn js-lang-menu-btn js-popup-menu-btn js-prevent-sideclick lang-flag lang-flag-{{ page.language_code }}" data-lang-code="{{ page.language_code }}" {{  edy_intro_add_lang }}>
         <span class="lang-title">
           {% for language in site.languages %}{% if language.selected? %}<span class="lang-title-inner js-lang-title-inner">{{ language.title }}</span>{% endif %}{% endfor %}
         </span>

--- a/components/menu-main.tpl
+++ b/components/menu-main.tpl
@@ -14,7 +14,7 @@
         <li>{% menubtn site.hidden_menuitems %}</li>
       {% endif %}
 
-      <li>{% menuadd %}</li>
+      <li {{ edy_intro_add_page }}>{% menuadd %}</li>
     </ul>
   {% endif %}
 </nav>

--- a/components/site-header.tpl
+++ b/components/site-header.tpl
@@ -56,7 +56,7 @@
 
         {% if front_page %}
           <div class="wrap">
-            <div class="header-body content-area">
+            <div class="header-body content-area" {{ edy_intro_edit_text }}>
               {% content name="header" %}
             </div>
           </div>

--- a/components/site-header.tpl
+++ b/components/site-header.tpl
@@ -74,7 +74,7 @@
           </div>
         {% else %}
           <div class="wrap">
-            <div class="header-body content-area">
+            <div class="header-body content-area" {{ edy_intro_edit_text }}>
               {% contentblock name="header" publish_default_content="true" %}<h1 style="text-align: center;">{{ page.title }}</h1>{% endcontentblock %}
             </div>
           </div>

--- a/components/template-variables.tpl
+++ b/components/template-variables.tpl
@@ -488,4 +488,10 @@
       }
     ]
   {% endcapture %}
+
+  {% comment %}VOOG intro popover targets. Add them where applicable popovers should appear.{% endcomment %}
+  {% capture edy_intro_add_page %}{% if editmode %}data-edy-intro-popover="edy-add-page"{% endif %}{% endcapture %}
+  {% capture edy_intro_add_lang %}{% if editmode %}data-edy-intro-popover="edy-add-lang"{% endif %}{% endcapture %}
+  {% capture edy_intro_edit_text %}{% if editmode %}data-edy-intro-popover="edy-edit-text"{% endif %}{% endcapture %}
+
 {% endcapture %}


### PR DESCRIPTION
Current targetable areas are:

```
data-edy-intro-popover="edy-add-page"
data-edy-intro-popover="edy-add-lang"
data-edy-intro-popover="edy-edit-text"
```
