### PR TITLE
Use `obj.og_description` for OG description

### DIFF
--- a/components/template-meta.tpl
+++ b/components/template-meta.tpl
@@ -41,9 +41,9 @@
 {% endif %}
 
 {% comment %}Open Graph description{% endcomment %}
-{%- if og_obj.description != blank -%}
-  <meta property="og:description" content="{{ og_obj.description | strip_html | escape_once }}">
-  <meta name="description" content="{{ og_obj.description | strip_html | escape_once }}">
+{%- if og_obj.og_description != blank -%}
+  <meta property="og:description" content="{{ og_obj.og_description | strip_html | escape_once }}">
+  <meta name="description" content="{{ og_obj.og_description | strip_html | escape_once }}">
 {%- endif -%}
 
 {% comment %}SEO pagination for blog articles.{% endcomment %}


### PR DESCRIPTION
Use `obj.og_description` for OG description to ensure that product's OG description is rendered correctly on auto-rendered product pages.

Closes #358 